### PR TITLE
Updated to support regions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,45 @@
 # onetimesecret-cli
 
-A simple python client to use the onetimesecret API https://onetimesecret.com/docs/api
+A simple Python client for interacting with the [OneTimeSecret API](https://onetimesecret.com/docs/api), allowing you to securely share secrets with a customizable expiration time and region support.
 
-## Install
+# Installation
+
+Install via pip:
 
 `pip install onetimesecret`
 
-## Ussage
+# Usage
 
+To use the OneTimeSecretCli client, import the class and initialize it with your OneTimeSecret API credentials. You can optionally specify a default region (e.g., "us" or "eu").
 ```
 from onetimesecret import OneTimeSecretCli
 
-cli = OneTimeSecretCli(ONETIMESECRET_USER, ONETIMESECRET_KEY)
-cli.create_link("secret") # return a link like https://onetimesecret.com/secret/xxxxxxxxxxx
+# Replace with your OneTimeSecret credentials and preferred region
+ONETIMESECRET_USER = "your_username"
+ONETIMESECRET_KEY = "your_api_key"
+REGION = "us"  # Default region, can be "us" or "eu"
+
+# Initialize the client
+cli = OneTimeSecretCli(ONETIMESECRET_USER, ONETIMESECRET_KEY, REGION)
+
+# Create a link for a secret message with a specified Time-to-Live (TTL)
+link = cli.create_link("Your secret message here")
+print("Secret link:", link)
 ```
+
+# Parameters
+## Initialization
+`cli = OneTimeSecretCli(ONETIMESECRET_USER, ONETIMESECRET_KEY, REGION)`
+- ONETIMESECRET_USER (str): Your OneTimeSecret API username (usually your account email).
+- ONETIMESECRET_KEY (str): Your OneTimeSecret API key.
+- REGION (str, optional): The region subdomain to use for API requests. Defaults to "us". Use "eu" for Europe. See Onetimesecret's website for the latest regions available.
+
+## Creating a Link
+`create_link(secret, ttl=900)`
+- secret (str): The secret message you want to securely share.
+- ttl (int, optional): The time-to-live for the secret in seconds (e.g., 900 for 15 minutes). Defaults to 900 seconds.
+# Expected Output
+
+Running the above example will print a secure link that can be shared:
+
+Secret link: https://us.onetimesecret.com/secret/xxxxxxxxxxx

--- a/onetimesecret/onetimesecret.py
+++ b/onetimesecret/onetimesecret.py
@@ -1,7 +1,8 @@
 import requests
 from requests.auth import HTTPBasicAuth
 
-URL = "https://onetimesecret.com"
+# Default base URL template with region
+URL_TEMPLATE = "https://{}.onetimesecret.com"
 
 
 class OneTimeSecretCli(object):
@@ -14,7 +15,8 @@ class OneTimeSecretCli(object):
 
         return "{}/secret/{}".format(self.url, response.json()["secret_key"])
 
-    def __init__(self, user, key, url=URL):
+    def __init__(self, user, key, url=URL_TEMPLATE, region="us"):
         self.key = key
         self.url = url
         self.user = user
+        self.url = URL_TEMPLATE.format(region)  # URL dynamically includes region


### PR DESCRIPTION
## Summary by Sourcery

Add region support to the OneTimeSecretCli client, allowing users to specify a regional subdomain for API requests. Update the README to reflect these changes and improve clarity on installation and usage.

New Features:
- Add support for specifying a region when initializing the OneTimeSecretCli client, allowing users to choose between different regional subdomains for API requests.

Enhancements:
- Update the README documentation to include instructions on how to specify a region and set a default region when using the OneTimeSecretCli client.

Documentation:
- Revise the README to provide clearer installation and usage instructions, including details on region support and parameter descriptions.